### PR TITLE
Clean up the shallow copy

### DIFF
--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -137,9 +137,9 @@ class DataModel(abc.ABC):
         """Ensure closure of resources when deleted."""
         self.close()
 
-    def copy(self, memo=None):
+    def copy(self, deepcopy=True, memo=None):
         result = self.__class__(init=None)
-        self.clone(result, self, deepcopy=True, memo=memo)
+        self.clone(result, self, deepcopy=deepcopy, memo=memo)
         return result
 
     __copy__ = __deepcopy__ = copy

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -56,9 +56,7 @@ def rdm_open(init, memmap=False, **kwargs):
         if isinstance(init, asdf.AsdfFile):
             asdffile = init
         elif isinstance(init, DataModel):
-            res = init.__class__(init=None)
-            init.clone(res, init, deepcopy=False)
-            return res
+            return init.copy(deepcopy=False)
         else:
             try:
                 kwargs["copy_arrays"] = not memmap


### PR DESCRIPTION
This is a suggestion for your spacetelescope/roman_datamodels#232 pull request.

I thought the way you had to make a shallow copy was very awkward, so I updated it so that it was less awkward. Feel free to reject, copy, or merge this suggestion.